### PR TITLE
Refactor toast dismissal logic in dashboard

### DIFF
--- a/logs/.274ccf5e9f41f9e73c70cf5e7e2b2ec735508d6b-audit.json
+++ b/logs/.274ccf5e9f41f9e73c70cf5e7e2b2ec735508d6b-audit.json
@@ -6,24 +6,14 @@
     "auditLog": "D:\\github_desktop\\mrn-lib-testing\\logs\\.274ccf5e9f41f9e73c70cf5e7e2b2ec735508d6b-audit.json",
     "files": [
         {
-            "date": 1762166317120,
-            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\app-2025-11-03.log",
-            "hash": "20b5cdf54ddcec286daacea604f1ab0911dbc4fa1c30425787f919fd95d59ff6"
-        },
-        {
-            "date": 1762194696091,
-            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\app-2025-11-04.log",
-            "hash": "044b8e75043f285de89b700e152cd3ea5a82edd2cd9666604bd008afd4a3b0e8"
-        },
-        {
-            "date": 1762345438369,
-            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\app-2025-11-05.log",
-            "hash": "f567f97dcf6533e4b92ab9291c4060205c2ca629686fc72e688b731d232a780d"
-        },
-        {
             "date": 1762367457354,
             "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\app-2025-11-06.log",
             "hash": "fe107a8e5d56347a8e5aa01408a9184aa098d5237ddf8dfadd3cbcd92fa9d507"
+        },
+        {
+            "date": 1762623383854,
+            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\app-2025-11-08.log",
+            "hash": "2df1c760e0191bc20fb9e3652449b26eefbb0940bf58e729fef321a0a4015438"
         }
     ],
     "hashType": "sha256"

--- a/logs/.2b0cbb59a4f86d21782b067bba8dd6cff50f19c0-audit.json
+++ b/logs/.2b0cbb59a4f86d21782b067bba8dd6cff50f19c0-audit.json
@@ -6,21 +6,6 @@
     "auditLog": "D:\\github_desktop\\mrn-lib-testing\\logs\\.2b0cbb59a4f86d21782b067bba8dd6cff50f19c0-audit.json",
     "files": [
         {
-            "date": 1761794192931,
-            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\rejections-2025-10-30.log",
-            "hash": "a02782c3446ca34aeb558ed06e8b0d7d534dea502e2261337b945316530b61cb"
-        },
-        {
-            "date": 1761926628453,
-            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\rejections-2025-10-31.log",
-            "hash": "21f60572c7e0959c7ecca42a5d5717879a4bc23f7590be61e717edb0eabfd140"
-        },
-        {
-            "date": 1761972706125,
-            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\rejections-2025-11-01.log",
-            "hash": "cda883d37000b8ef840eee9860259d2f9b104e39d8c117ff14330fefe744116c"
-        },
-        {
             "date": 1762166317404,
             "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\rejections-2025-11-03.log",
             "hash": "49611f8270fdbae8ab334fc7e11f2a82f1c10a7e397a3b0ea91daa855c6335ba"
@@ -39,6 +24,11 @@
             "date": 1762367457780,
             "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\rejections-2025-11-06.log",
             "hash": "744defb94f8946efed0f961e74370f7f8e7761bdaf24185688aa108147c47570"
+        },
+        {
+            "date": 1762623391494,
+            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\rejections-2025-11-08.log",
+            "hash": "9a50471045aae413635807d9fd1825db544d3eaba30dcafd87ff523ae23d3694"
         }
     ],
     "hashType": "sha256"

--- a/logs/.933939d917bef75ccb98555a8e7e109a95b6b7e9-audit.json
+++ b/logs/.933939d917bef75ccb98555a8e7e109a95b6b7e9-audit.json
@@ -6,21 +6,6 @@
     "auditLog": "D:\\github_desktop\\mrn-lib-testing\\logs\\.933939d917bef75ccb98555a8e7e109a95b6b7e9-audit.json",
     "files": [
         {
-            "date": 1761794192851,
-            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\error-2025-10-30.log",
-            "hash": "bf30035f1bc53f8db738450aedb2ebdc3563ecbc42d3b13fe7c24b958948bb0d"
-        },
-        {
-            "date": 1761926628348,
-            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\error-2025-10-31.log",
-            "hash": "c3b74c86d19a009a668914b46a14cdf83d00dedeb88d3bcb7ad2b13919ab4947"
-        },
-        {
-            "date": 1761972705899,
-            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\error-2025-11-01.log",
-            "hash": "140db8acf6f266424b1aa00a4c1464d8ad37a20f0d77860cdf43ca6f2d0e4f7e"
-        },
-        {
             "date": 1762166317243,
             "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\error-2025-11-03.log",
             "hash": "b09b8b2850946c404d83f70d130044c26c0c7a3fd66642b47b5bbe2963599632"
@@ -39,6 +24,11 @@
             "date": 1762367457469,
             "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\error-2025-11-06.log",
             "hash": "047ce31afd402fe867a6eeb4a46989d5d57cc16355abcfb6d3c1fac17fe23966"
+        },
+        {
+            "date": 1762623386681,
+            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\error-2025-11-08.log",
+            "hash": "8577001fc7a55c6dea0062087bf901d38cdfc78121bf9107d73821e464c80d02"
         }
     ],
     "hashType": "sha256"

--- a/logs/.c4591fe27f7e7fa3f9895fa185c763c1ecb7e03c-audit.json
+++ b/logs/.c4591fe27f7e7fa3f9895fa185c763c1ecb7e03c-audit.json
@@ -6,21 +6,6 @@
     "auditLog": "D:\\github_desktop\\mrn-lib-testing\\logs\\.c4591fe27f7e7fa3f9895fa185c763c1ecb7e03c-audit.json",
     "files": [
         {
-            "date": 1761794192924,
-            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\exceptions-2025-10-30.log",
-            "hash": "d2356daab702e073eaef331918fe0a9d34713f7377c4749a8ce1b612fda25616"
-        },
-        {
-            "date": 1761926628430,
-            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\exceptions-2025-10-31.log",
-            "hash": "d1c6399e7e8bed251d59360eaa94e14c3d705485750e154be3a7c9a408751137"
-        },
-        {
-            "date": 1761972706083,
-            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\exceptions-2025-11-01.log",
-            "hash": "72ddd816d255450f31d1da7ee0e78ced45adeb54c7ffd1c1bcf205a759dca9ee"
-        },
-        {
             "date": 1762166317347,
             "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\exceptions-2025-11-03.log",
             "hash": "a338468a48edf459b1f5bc7c042cf109ac8cba15c03f948527b5d812f8080aea"
@@ -39,6 +24,11 @@
             "date": 1762367457672,
             "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\exceptions-2025-11-06.log",
             "hash": "28fc5190945782d2219308339ab55193986f8f6a908d82bc18cfc32504439963"
+        },
+        {
+            "date": 1762623388555,
+            "name": "D:\\github_desktop\\mrn-lib-testing\\logs\\exceptions-2025-11-08.log",
+            "hash": "77f793fd1be788a4d7ed668e85a5c403a10f2a88b095e26100b3a13d80c116dc"
         }
     ],
     "hashType": "sha256"

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1631,7 +1631,7 @@
 
         static dismissAll() {
           if (typeof customizableToast?.dismiss === "function") {
-            customizableToast.dismiss();
+            customizableToast.customizableToast.noop()();
           } else if (typeof customizableToast?.noop === "function") {
             customizableToast.noop();
           }
@@ -1779,7 +1779,7 @@
         const loading = ToastManager.loading("Sending test email...", {
           label: "Cancel",
           onClick: () => {
-            ToastManager.dismissAll();
+            customizableToast.noop();
             ToastManager.warning("Email sending cancelled");
             ActivityLogger.log("Email sending cancelled", "warning");
           },
@@ -1791,7 +1791,7 @@
           body: JSON.stringify({ email, templateType: template }),
         });
 
-        loading.dismiss();
+        customizableToast.noop();
 
         if (result.success) {
           ToastManager.success(`✅ Email sent to ${email}`, {
@@ -1830,7 +1830,7 @@
           ActivityLogger.log("Bulk email sending started");
 
           const result = await apiCall("/send-bulk-now", { method: "POST" });
-          loading.dismiss();
+          customizableToast.noop();
 
           if (result.success) {
             const successCount = result.data.successCount || 0;
@@ -1896,7 +1896,7 @@
                 body: JSON.stringify({ days }),
               });
 
-              loading.dismiss();
+              customizableToast.noop();
 
               if (result.success) {
                 const deleted = result.data.deleted || 0;
@@ -1963,9 +1963,10 @@
 
       /* ==================== System Health ==================== */
       async function systemHealth() {
-        const loading = ToastManager.loading("Checking system health...");
+        ToastManager.loading("Checking system health...");
+
         const result = await apiCall("/health");
-        loading.dismiss();
+        customizableToast.noop();
 
         if (result.success && result.data) {
           const status = result.data.status || "unknown";
@@ -2037,7 +2038,7 @@
           const loading = ToastManager.loading("Reading database...");
 
           const result = await apiCall("/read-db");
-          loading.dismiss();
+          customizableToast.noop();
 
           if (result.success && result.data) {
             const jsonData = JSON.stringify(result.data, null, 2);
@@ -2088,8 +2089,8 @@
                 {
                   duration: 5000,
                   cta: {
-                    label: "Dismiss All",
-                    onClick: () => ToastManager.dismissAll(),
+                    label: "customizableToast.noop() All",
+                    onClick: () => customizableToast.noop(),
                   },
                 }
               );
@@ -2167,7 +2168,7 @@
       /* ==================== Keyboard Shortcuts ==================== */
       document.addEventListener("keydown", (e) => {
         if (e.key === "Escape") {
-          ToastManager.dismissAll();
+          customizableToast.noop();
         }
 
         // Ctrl/Cmd + K for quick actions


### PR DESCRIPTION
Replaces calls to ToastManager.dismissAll and loading.dismiss with customizableToast.noop() throughout dashboard.html for consistency. Updates audit log JSON files to include new log entries for November 8, 2025 and removes older entries.